### PR TITLE
Update template.html

### DIFF
--- a/theme/csc-plain/template.html
+++ b/theme/csc-plain/template.html
@@ -113,6 +113,9 @@ $endif$
       // Full list of configuration options available at:
       // https://revealjs.com/config/
       Reveal.initialize({
+        // Don't separate framgents for pdf output
+        pdfSeparateFragments: false, 
+        
         // Display controls in the bottom right corner
         controls: $controls$,
 


### PR DESCRIPTION
Default to `pdfSeparateFragments: false` in `csc-plain/template.html`.

This will cause pdf files to have way less pages with presentations which use {.incremental} and {.fragments}.