### PR TITLE
Build slidefactory on debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,10 @@ FROM docker.io/debian:bookworm-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# General packages
 RUN apt-get update -qy && \
     apt-get install -qy --no-install-recommends \
       ca-certificates \
-      chromium \
       git \
       fonts-freefont-otf \
       fonts-liberation \
@@ -43,10 +43,31 @@ RUN apt-get update -qy && \
       && \
     apt-get clean
 
-# Install pandoc
-RUN wget https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-1-amd64.deb -O tmp.deb && \
-    dpkg -i tmp.deb && \
-    rm -f tmp.deb
+# Dependencies of chromium
+RUN apt-get update -qy && \
+    apt-get install -qy --no-install-recommends \
+      chromium \
+      && \
+    apt-get remove -qy \
+      chromium \
+      chromium-common \
+      && \
+    apt-get clean
+
+# Fonts
+RUN FONT_DIR=NotoSans && \
+    mkdir -p /slidefactory/fonts/$FONT_DIR && \
+    wget https://github.com/notofonts/latin-greek-cyrillic/releases/download/NotoSans-v2.013/NotoSans-v2.013.zip -O tmp.zip && \
+    unzip -j tmp.zip 'NotoSans/googlefonts/ttf/*' -d /slidefactory/fonts/$FONT_DIR && \
+    unzip -j tmp.zip 'OFL.txt' -d /slidefactory/fonts/$FONT_DIR && \
+    rm tmp.zip
+
+RUN FONT_DIR=Inconsolata && \
+    mkdir -p /slidefactory/fonts/$FONT_DIR && \
+    wget https://github.com/googlefonts/Inconsolata/archive/refs/tags/v3.000.zip -O tmp.zip && \
+    unzip -j tmp.zip 'Inconsolata-3.000/fonts/ttf/Inconsolata-*' -x '*Condensed*' '*Expanded*' -d /slidefactory/fonts/$FONT_DIR && \
+    unzip -j tmp.zip 'Inconsolata-3.000/OFL.txt' -d /slidefactory/fonts/$FONT_DIR && \
+    rm tmp.zip
 
 # Reveal.js
 RUN wget https://github.com/hakimel/reveal.js/archive/refs/tags/4.4.0.zip -O tmp.zip && \
@@ -64,20 +85,17 @@ RUN wget https://github.com/mathjax/MathJax/archive/refs/tags/3.2.2.zip -O tmp.z
     unzip tmp.zip 'MathJax-3.2.2/es5/adaptors/*' -d /slidefactory && \
     rm -f tmp.zip
 
-# Fonts
-RUN FONT_DIR=NotoSans && \
-    mkdir -p /slidefactory/fonts/$FONT_DIR && \
-    wget https://github.com/notofonts/latin-greek-cyrillic/releases/download/NotoSans-v2.013/NotoSans-v2.013.zip -O tmp.zip && \
-    unzip -j tmp.zip 'NotoSans/googlefonts/ttf/*' -d /slidefactory/fonts/$FONT_DIR && \
-    unzip -j tmp.zip 'OFL.txt' -d /slidefactory/fonts/$FONT_DIR && \
-    rm tmp.zip
+# Pandoc
+RUN wget https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-1-amd64.deb -O tmp.deb && \
+    dpkg -i tmp.deb && \
+    rm -f tmp.deb
 
-RUN FONT_DIR=Inconsolata && \
-    mkdir -p /slidefactory/fonts/$FONT_DIR && \
-    wget https://github.com/googlefonts/Inconsolata/archive/refs/tags/v3.000.zip -O tmp.zip && \
-    unzip -j tmp.zip 'Inconsolata-3.000/fonts/ttf/Inconsolata-*' -x '*Condensed*' '*Expanded*' -d /slidefactory/fonts/$FONT_DIR && \
-    unzip -j tmp.zip 'Inconsolata-3.000/OFL.txt' -d /slidefactory/fonts/$FONT_DIR && \
-    rm tmp.zip
+# Chromium
+RUN apt-get update -qy && \
+    apt-get install -qy --no-install-recommends \
+      chromium \
+      && \
+    apt-get clean
 
 COPY --from=slidefactory-files /slidefactory/ /slidefactory/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3.17 AS slidefactory-files
+FROM docker.io/debian:bookworm-slim AS slidefactory-files
 
 ARG VERSION
 
@@ -23,22 +23,26 @@ RUN cd /slidefactory && \
     mv /tmp/sha256sums_$VERSION /slidefactory/
 
 
-FROM docker.io/alpine:3.17
+FROM docker.io/debian:bookworm-slim
 
-RUN apk update && \
-    apk add --no-cache \
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qy && \
+    apt-get install -qy --no-install-recommends \
       ca-certificates \
       chromium \
       git \
       pandoc \
-      font-freefont \
+      fonts-freefont-otf \
+      fonts-liberation \
       python3 \
-      py3-pandocfilters \
-      py3-yaml \
+      python3-pandocfilters \
+      python3-yaml \
       tar \
-      zip \
+      wget \
+      zip unzip \
       && \
-    rm -rf /var/cache/apk/*
+    apt-get clean
 
 # Reveal.js
 RUN wget https://github.com/hakimel/reveal.js/archive/refs/tags/4.4.0.zip -O tmp.zip && \
@@ -74,7 +78,7 @@ RUN FONT_DIR=Inconsolata && \
 COPY --from=slidefactory-files /slidefactory/ /slidefactory/
 
 # Create executable
-RUN echo -e '#!/bin/sh\n\
+RUN echo '#!/bin/sh\n\
 exec python3 /slidefactory/slidefactory.py "$@"\n\
 ' > /usr/bin/slidefactory && \
     chmod a+x /usr/bin/slidefactory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/debian:bookworm-slim AS slidefactory-files
+FROM docker.io/debian:bookworm AS slidefactory-files
 
 ARG VERSION
 
@@ -23,7 +23,7 @@ RUN cd /slidefactory && \
     mv /tmp/sha256sums_$VERSION /slidefactory/
 
 
-FROM docker.io/debian:bookworm-slim
+FROM docker.io/debian:bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ RUN apt-get update -qy && \
       ca-certificates \
       chromium \
       git \
-      pandoc \
       fonts-freefont-otf \
       fonts-liberation \
       python3 \
@@ -43,6 +42,11 @@ RUN apt-get update -qy && \
       zip unzip \
       && \
     apt-get clean
+
+# Install pandoc
+RUN wget https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-1-amd64.deb -O tmp.deb && \
+    dpkg -i tmp.deb && \
+    rm -f tmp.deb
 
 # Reveal.js
 RUN wget https://github.com/hakimel/reveal.js/archive/refs/tags/4.4.0.zip -O tmp.zip && \

--- a/slidefactory.py
+++ b/slidefactory.py
@@ -228,7 +228,7 @@ def copy_html_externals(input_fpath, html_fpath):
 
 def create_pdf(html_fpath, pdf_fpath):
     run_args = [
-        'chromium-browser',
+        'chromium',
         '--no-sandbox',
         '--headless',
         '--disable-gpu',

--- a/slidefactory.py
+++ b/slidefactory.py
@@ -25,7 +25,7 @@ from urllib.parse import quote as urlquote, urlparse
 from pathlib import Path
 
 
-VERSION = "3.2.0-beta.2"
+VERSION = "3.3.0"
 SLIDEFACTORY_ROOT = Path(__file__).absolute().parent
 IN_CONTAINER = SLIDEFACTORY_ROOT == Path('/slidefactory')
 


### PR DESCRIPTION
This PR will switch slidefactory from alpine to debian due to pdf generation issues with chromium on alpine. Pandoc is installed manually to match the earlier version 2.19.2. Debian repository's pandoc version 2.17.1 doesn't produce the same output for all tested slides.

In addition, the instructions in dockerfile are sorted according to expected update frequency to help caching.