### PR TITLE
Fix pandoc filters calling python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,14 @@ RUN apt-get update -qy && \
       && \
     apt-get clean
 
+# Fix pandoc filters calling python;
+# Move this higher up when updating earlier blobs
+RUN apt-get update -qy && \
+    apt-get install -qy --no-install-recommends \
+      python-is-python3 \
+      && \
+    apt-get clean
+
 COPY --from=slidefactory-files /slidefactory/ /slidefactory/
 
 # Create executable

--- a/slidefactory.py
+++ b/slidefactory.py
@@ -25,7 +25,7 @@ from urllib.parse import quote as urlquote, urlparse
 from pathlib import Path
 
 
-VERSION = "3.3.0"
+VERSION = "3.3.1"
 SLIDEFACTORY_ROOT = Path(__file__).absolute().parent
 IN_CONTAINER = SLIDEFACTORY_ROOT == Path('/slidefactory')
 


### PR DESCRIPTION
The PR will fix pandoc filters calling python (instead of python3). Example error log [here](https://github.com/csc-training/summerschool/actions/runs/15348373245/job/43190021019).